### PR TITLE
Add per-response-type duration

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -46,6 +46,7 @@ Curt Micol <asenchi@asenchi.com>
 Dan Callaghan <dcallagh@redhat.com>
 Dan Sully <daniel-github@electricrain.com>
 Daniel Quinn <code@danielquinn.org>
+Danny Sauer <danny.sauer@konghq.com>
 Dariusz Suchojad <dsuch-github@m.zato.io>
 David Black <github@dhb.is>
 David Vincelli <david@freshbooks.com>

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -100,6 +100,7 @@ class Statsd(Logger):
         self.histogram("gunicorn.request.duration", duration_in_ms)
         self.increment("gunicorn.requests", 1)
         self.increment("gunicorn.request.status.%d" % status, 1)
+        self.histogram("gunicorn.request.status.%d.duration" % status, duration_in_ms)
 
     # statsD methods
     # you can use those directly if you want

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -103,6 +103,7 @@ def test_instrument():
     assert logger.sock.msgs[0] == b"gunicorn.request.duration:7000.0|ms"
     assert logger.sock.msgs[1] == b"gunicorn.requests:1|c|@1.0"
     assert logger.sock.msgs[2] == b"gunicorn.request.status.200:1|c|@1.0"
+    assert logger.sock.msgs[3] == b"gunicorn.request.status.200.duration:7000.0|ms"
 
 
 def test_prefix():


### PR DESCRIPTION
It's sometimes useful to know response time separated out by status code.  Add another histogram for that.

I think it makes a little more sense as a subgroup under `request.status.xxx.duration`, but I'm also ok with `request.duration.status.xxxx` if someone has a strong opinion.